### PR TITLE
Add `mix` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,52 @@ Minimalist mixin helper designed to be used with ES6 (ES2015) classes.
 Installation
 ------------
 
-    npm install --save es6-mixin
+``` shell
+npm install --save es6-mixin
+```
 
 Usage
 -----
 
-### Basic usage
+### `mix(SuperClass, Mixin1, Mixin2, ...)`
 
-```javascript
+``` javascript
+import { mix } from 'es6-mixin';
+
+class Super {
+  foo() {
+    return 'foo';
+  }
+}
+
+class Mixin1 {
+  bar () {
+    return 'bar';
+  }
+}
+
+class Mixin2 {
+  baz () {
+    return 'baz';
+  }
+}
+
+class Sub extends mix(Super, Mixin1, Mixin2) {
+}
+
+new Sub().foo(); // => 'foo'
+new Sub().bar(); // => 'bar'
+new Sub().baz(); // => 'baz'
+new Sub() instanceof Super; // => true
+new Sub() instanceof Mixin1; // => false
+new Sub() instanceof Mixin2; // => false
+```
+
+### `mixin(target, Mixin [, arg1, arg2, ...])`
+
+#### Basic usage
+
+``` javascript
 import { mixin } from 'es6-mixin';
 
 class Foo {
@@ -41,9 +79,9 @@ class Bar {
 new Bar().foo(); // => 'foo'
 ```
 
-### Pass parameters to a constructor
+#### Pass parameters to a constructor
 
-```javascript
+``` javascript
 import { mixin } from 'es6-mixin';
 
 class Foo {
@@ -63,9 +101,9 @@ class Bar {
 new Bar().foo(); // => 'foo'
 ```
 
-### Use with ES5-style prototypes
+#### Use with ES5-style prototypes
 
-```javascript
+``` javascript
 import { mixin } from 'es6-mixin';
 
 function Foo() {
@@ -84,10 +122,10 @@ class Bar {
 new Bar().foo(); // => 'foo'
 ```
 
-### Use the `Mixin` superclass
+### `class extends Mixin { ... }`
 
-```javascript
-import { mixin } from 'es6-mixin';
+``` javascript
+import { Mixin } from 'es6-mixin';
 
 class Foo extends Mixin {
   foo() {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "keywords": [
     "mixin",
     "mixins",
+    "mix",
+    "combine",
     "es6",
     "es2015",
     "es7",

--- a/specs/lib/index.spec.js
+++ b/specs/lib/index.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import sinon, { spy } from 'sinon';
-import { mixin, Mixin } from '../../src/lib/index';
+import { mixin, mix, Mixin } from '../../src/lib/index';
 import { getFixture } from './fixture';
 import { itExists, itIsAFunction } from './helpers';
 
@@ -24,6 +24,64 @@ describe('mixin', () => {
 
     mixin(target, ExistingClass, 1, 2, 3);
     sinon.assert.calledWith(initSpy, 1, 2, 3);
+  });
+});
+
+/** @test {mix} */
+describe('mix', () => {
+  itExists(mixin);
+  itIsAFunction(mixin);
+
+  it('creates a new class', () => {
+    const { ExistingClass } = getFixture();
+    const SubClass = mix(ExistingClass);
+    expect(SubClass).to.be.a('function');
+    expect(new SubClass()).to.be.an.instanceof(SubClass);
+  });
+
+  it('creates a class that extends the given superclass', () => {
+    class Foo {
+      foo() {}
+    }
+    const SubClass = mix(Foo);
+    expect(new SubClass()).to.be.an.instanceof(Foo);
+    expect(new SubClass().init).to.equal(Foo.prototype.init);
+  });
+
+  it('mixes in all given mixins', () => {
+    class Foo {
+      foo() {}
+    }
+    class Bar {
+      bar() {}
+    }
+    class Baz {
+      baz() {}
+    }
+    const SubClass = mix(Foo, Bar, Baz);
+    expect(new SubClass()).not.to.have.key('foo');
+    expect(new SubClass()).to.have.all.keys('bar', 'baz');
+  });
+
+  it('overwrite methods in the given order', () => {
+    class Foo {
+      foo() {
+        return 'Foo';
+      }
+    }
+    class FOo {
+      foo() {
+        return 'FOo';
+      }
+    }
+    class FOO {
+      foo() {
+        return 'FOO';
+      }
+    }
+
+    expect(new (mix(Foo, FOO))().foo()).to.equal('FOO');
+    expect(new (mix(Foo, FOo, FOO))().foo()).to.equal('FOO');
   });
 });
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -55,8 +55,8 @@ export function mixin(target = {}, MixedIn = Mixin, ...args) {
  */
 export function mix(SuperClass, ...mixins) {
   return class extends SuperClass {
-    constructor() {
-      super();
+    constructor(...args) {
+      super(...args);
       mixins.forEach(Mixedin => mixin(this, Mixedin));
     }
   };

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -18,7 +18,7 @@ export class Mixin {
   /**
    * Mixes in this class's methods into an existing object.
    * @param {object} [target={}] Any object to mix this class's methods into
-   * @param {object} [MixedIn=this] Constructor to be mixed in
+   * @param {function} [MixedIn=this] Constructor to be mixed in
    * @param {...*} [args] Arguments to pass to the mixed in constructor, if any
    * @return {object} The original target object, mutated
    */
@@ -39,10 +39,25 @@ export class Mixin {
 /**
  * Mixes in this class's methods into an existing object.
  * @param {object} [target={}] Any object to mix this class's methods into
- * @param {object} [MixedIn=Mixin] Constructor to be mixed in
+ * @param {function} [MixedIn=Mixin] Constructor to be mixed in
  * @param {...*} [args] Arguments to pass to the mixed in constructor, if any
  * @return {object} The original target object, mutated
  */
 export function mixin(target = {}, MixedIn = Mixin, ...args) {
   return Mixin.mixin(target, MixedIn, ...args);
+}
+
+/**
+ * Create a subclass of a constructor and mix 1 or many mixin into it.
+ * @param {function} SuperClass Class that will be used as super-class
+ * @param {...function} mixins Mixin to add
+ * @return {function} A new anonymous class that extends `SuperClass` and has all `mixins` mixed in
+ */
+export function mix(SuperClass, ...mixins) {
+  return class extends SuperClass {
+    constructor() {
+      super();
+      mixins.forEach(Mixedin => mixin(this, Mixedin));
+    }
+  };
 }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -50,7 +50,7 @@ export function mixin(target = {}, MixedIn = Mixin, ...args) {
 /**
  * Create a subclass of a constructor and mix 1 or many mixin into it.
  * @param {function} SuperClass Class that will be used as super-class
- * @param {...function} mixins Mixin to add
+ * @param {...function} mixins Mixins to add
  * @return {function} A new anonymous class that extends `SuperClass` and has all `mixins` mixed in
  */
 export function mix(SuperClass, ...mixins) {


### PR DESCRIPTION
The `mix` helper can be used as in:

``` javascript
import { mix } from 'es6-mixin';

class Super {
  foo() {
    return 'foo';
  }
}

class Mixin1 {
  bar () {
    return 'bar';
  }
}

class Mixin2 {
  baz () {
    return 'baz';
  }
}

class Sub extends mix(Super, Mixin1, Mixin2) {
}

new Sub().foo(); // => 'foo'
new Sub().bar(); // => 'bar'
new Sub().baz(); // => 'baz'
new Sub() instanceof Super; // => true
new Sub() instanceof Mixin1; // => false
new Sub() instanceof Mixin2; // => false
```

Note: this helpers is inspired by [In defense of JavaScript’s constructors](http://www.2ality.com/2013/07/defending-constructors.html) and [Classes in ECMAScript 6 (final semantics)](http://www.2ality.com/2015/02/es6-classes-final.html) by Axel Rauschmayer.

---
- [x] Implementation
- [x] Specs
- [x] Documentation
